### PR TITLE
Fix Detekt warnings for buildSrc and build scripts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,14 +8,14 @@ plugins {
 }
 
 android {
-    compileSdkVersion(28)
+    compileSdkVersion(Android.targetSdk)
     defaultConfig {
-        applicationId = "io.austinray.slauncher"
-        minSdkVersion(19)
-        targetSdkVersion(28)
-        versionCode = VersionCode.major * 100_000 +  VersionCode.minor * 1_000 + VersionCode.build
-        versionName = "${VersionCode.major}.${VersionCode.minor}.${VersionCode.build}"
-        testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
+        applicationId = Android.id
+        minSdkVersion(Android.minSdk)
+        targetSdkVersion(Android.targetSdk)
+        versionCode = Version.code
+        versionName = Version.name
+        testInstrumentationRunner = Android.instrumentationRunner
         vectorDrawables {
             useSupportLibrary = true
         }

--- a/buildSrc/src/main/kotlin/Configuration.kt
+++ b/buildSrc/src/main/kotlin/Configuration.kt
@@ -1,7 +1,21 @@
-object VersionCode {
-    val major = 0
-    val minor = 0
-    val build = 0
+object Version {
+    private val major = 0
+    private val minor = 2
+    private val build = 0
+
+    private const val majorIncrement = 100_000
+    private const val minorIncrement = 1_000
+
+    val code = major * majorIncrement +  minor * minorIncrement + build
+    val name = "$major.$minor.$build"
+}
+
+object Android {
+    const val id = "io.austinray.slauncher"
+    const val minSdk = 19
+    const val targetSdk = 28
+
+    const val instrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
 }
 
 object Versions {


### PR DESCRIPTION
Detekt was warning about magic numbers in the build scripts. This commit moves the magic numbers to constants inside Configuration.kt.